### PR TITLE
Removed bash prompt from code snippet so that copypaste works

### DIFF
--- a/content/ansible-tower-advanced/5-tower-cluster-jobs/_index.md
+++ b/content/ansible-tower-advanced/5-tower-cluster-jobs/_index.md
@@ -42,7 +42,7 @@ Replace **\<ID>** with the job ID you want to query!
 {{% /notice %}}
 
 ```bash
-    [student@ansible ~]$ curl -s -k -u admin:{{< param "secret_password" >}} https://{{< param "internal_tower1" >}}/api/v2/jobs/<ID>/ | python -m json.tool | grep execution_node
+    curl -s -k -u admin:{{< param "secret_password" >}} https://{{< param "internal_tower1" >}}/api/v2/jobs/<ID>/ | python -m json.tool | grep execution_node
 
         "execution_node": "{{< param "internal_tower1" >}}",
 ```


### PR DESCRIPTION
I suggest removing bash prompt from code snippets due to the JS copypaste function, so that using that button doesnt require cleaning up when pasting ;-)